### PR TITLE
fix(deps): update to cli-table3

### DIFF
--- a/cdocker
+++ b/cdocker
@@ -7,15 +7,15 @@ var Docker = require('dockerode');
 var pretty = require('prettysize');
 var rangeParser = require('parse-numeric-range');
 var deferred = require('deferred');
-var Table = require('cli-table2');
+var Table = require('cli-table3');
 var minimatch = require('minimatch');
 var expand = require('brace-expansion');
 var randomItem = require('random-item');
 var child_process = require('child_process');
 var yesNo = require('yes-no');
 yesNo.userTests.push(function(value) {
-    // Test functions should return a boolean for recognized 
-    // values, or anything else (or nothing) for unrecognized. 
+    // Test functions should return a boolean for recognized
+    // values, or anything else (or nothing) for unrecognized.
     if (value === 'on') {
         return true;
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "brace-expansion": "^1.1.8",
-    "cli-table2": "^0.2.0",
+    "cli-table3": "^0.5.0",
     "deferred": "^0.7.8",
     "dockerode": "^2.5.0",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
This PR updates the cli-table2 dependency to cli-table3, which fixes one of the npm audit warnings :)

cli-table2 (like cli-table itself) is no longer maintained. In jamestalmage/cli-table2#43 a couple of people have offered to take over maintenance but the current maintainer did not respond so as a result the project was forked to cli-table/cli-table3.
